### PR TITLE
Add AnimeListing component

### DIFF
--- a/src/frontend/src/components/AnimeListing.vue
+++ b/src/frontend/src/components/AnimeListing.vue
@@ -1,0 +1,162 @@
+<!--
+A component to display a listing of animes. It can be used to display
+animes by genre, alphabetically, or even a limited list (e.g. latest 10
+or so animes).
+
+Via props, the caller can customize the components, enabling or disabling
+features like pagination.
+
+Besides the props received from the caller, this component emits events
+that can be used by the caller to react to events such as when the user
+has selected an item from the drop down menu, or changed the listing page.
+-->
+<template>
+  <!-- all content -->
+  <div class="bg-white overflow-hidden">
+    <!-- top bar -->
+    <div class="border-b flex px-6 py-2 items-center flex-none">
+      <div class="flex flex-col">
+        <h3 class="text-grey-darkest mb-1 font-extrabold">
+          👑 {{ pageTitle }}
+        </h3>
+        <div class="text-grey-dark text-sm truncate">
+          💖 Enjoy the world of anime
+        </div>
+      </div>
+      <div class="flex-1 justify-center hidden sm:flex"></div>
+      <!-- href links to platforms and social media -->
+      <div class="flex justify-start items-center text-gray-500">
+        <h1 v-if="menuItem">{{ menuTitle }}</h1>
+        <select
+          v-model="menuItem"
+          v-if="menuOptions && menuOptions.length > 0"
+          class="list-reset border border-purple-200 rounded m-3 w-20 font-sans"
+        >
+          <option
+            v-for="(menuOption, index) in menuOptions"
+            :value="menuOption"
+            :key="index"
+          >
+            {{ menuOption }}
+          </option>
+        </select>
+        <a
+          href="https://github.com/ChrisMichaelPerezSantiago/ryuanime"
+          class="block flex items-center hover:text-gray-700 mr-5"
+        >
+          <svg
+            class="fill-current w-5 h-5"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+          >
+            <title>GitHub</title>
+            <path
+              d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0"
+            ></path>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <!-- content inside -->
+    <div class="px-6 py-4 flex-1" id="style-1">
+      <!-- [TEMPORARY SOLUTION] navbar for phones -->
+      <DropDownSection class="ddSection"></DropDownSection>
+      <div v-if="isLoading">
+        <div class="lds-roller">
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+      <div class="flex flex-wrap" v-else>
+        <div
+          class="w-full sm:w-1/2 md:w-1/2 lg:w-1/2 xl:w-1/2 mb-4"
+          v-for="(anime, index) in animes"
+          :key="index"
+        >
+          <LatestAnime :anime="anime"></LatestAnime>
+        </div>
+      </div>
+    </div>
+    <!-- pagination control, displayed only when pagination prop flag is true -->
+    <paginate
+      class="paginator-container list-reset border border-purple-200 rounded w-auto font-sans"
+      v-if="pagination"
+      v-model="page"
+      :page-count="animes.length"
+      :page-range="3"
+      :margin-pages="2"
+      :click-handler="() => $emit('page-selected', this.page)"
+      :prev-text="'Prev'"
+      :next-text="'Next'"
+      :container-class="'pagination'"
+      :page-class="'page-item'"
+    >
+    </paginate>
+  </div>
+</template>
+
+<script>
+import LatestAnime from "./LatestAnime";
+import DropDownSection from "./DropDownSection";
+import { mapState } from "vuex";
+
+export default {
+  name: "DefaultLayout",
+  components: {
+    LatestAnime,
+    DropDownSection
+  },
+  data() {
+    return {
+      menuItem: null, // drop down menu
+      page: 0 // pagination page selected
+    };
+  },
+  watch: {
+    menuItem: function() {
+      this.$emit("menu-item-selected", this.menuItem);
+    }
+  },
+  computed: {
+    ...mapState(["isLoading"])
+  },
+  created() {
+    this.menuItem = this.menuInitialValue;
+  },
+  props: {
+    // page title
+    pageTitle: {
+      type: String,
+      required: true
+    },
+    // anime data
+    animes: {
+      type: Array,
+      required: true
+    },
+    // dropdown menu information
+    menuTitle: {
+      type: String,
+      required: false
+    },
+    menuOptions: {
+      type: Array,
+      required: false
+    },
+    menuInitialValue: {
+      type: String,
+      required: false,
+      default: ""
+    },
+    // anime data controls
+    pagination: Boolean
+  }
+};
+</script>

--- a/src/frontend/src/views/AnimesByGender.vue
+++ b/src/frontend/src/views/AnimesByGender.vue
@@ -1,130 +1,62 @@
 <template>
-  <!-- all content -->
-  <div class="bg-white overflow-hidden">
-    <!-- top bar -->
-    <div class="border-b flex px-6 py-2 items-center flex-none">
-        <div class="flex flex-col">
-            <h3 class="text-grey-darkest mb-1 font-extrabold">👑 Animes by Genres</h3>
-            <div class="text-grey-dark text-sm truncate">
-              💖 Enjoy the world of anime
-            </div>
-        </div>
-
-        <div class="flex-1 justify-center hidden sm:flex">
-          <!--<v-suggest :data="animesByGender" type="text" placeholder="Search Anime ..." show-field="title" v-model="searchModel" class="border border-grey px-8 py-2 w-1/2 max-w-md outline-none rounded-l"></v-suggest> -->
-          <!--<input type="text" placeholder="Search Anime ..." class="border border-grey px-3 py-2 w-1/2 max-w-md outline-none rounded-l"/> -->
-
-            <!--<button class="flex justify-center items-center bg-grey-lighter px-6 border border-grey border-l-0 rounded-r focus:outline-none hover:bg-gray-100">
-
-            <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" class="w-5 opacity-50"><g>
-              <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-              </g>
-            </svg>
-          </button> -->
-        </div>
-        <!-- href links to platforms and social media -->
-        <div class="flex justify-start items-center text-gray-500">
-          <h1>Genres</h1>
-          <select class="list-reset border border-purple-200 rounded m-3 w-20 font-sans" v-model="gender">
-            <option v-for="(char , index) in options"
-              :value="char"
-              :key="index"
-            >
-              {{char}}
-            </option>
-          </select>
-
-
-          <a href="https://github.com/ChrisMichaelPerezSantiago/ryuanime" class="block flex items-center hover:text-gray-700 mr-5">
-            <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <title>GitHub</title>
-              <path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0">
-              </path>
-            </svg>
-          </a>
-        </div>
-    </div>
-
-
-    <!-- content inside -->
-    <div class="px-6 py-4 flex-1 overflow-y-scroll scrollbar" id="style-1">
-      <DropDownSection class="ddSection"/> <!-- [TEMPORARY SOLUTION] navabr for phones -->
-
-      <div v-if="isLoading">
-        <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
-      </div>
-      <div class="flex flex-wrap" v-else>
-        <div class="w-full sm:w-1/2 md:w-1/2 lg:w-1/2 xl:w-1/2 mb-4" v-for="(anime , index) in animesByGender" :key="index">
-          <LatestAnime :anime="anime"/>
-        </div>
-      </div>
-    </div>
-
-     <paginate
-      class="paginator-container list-reset border border-purple-200 rounded w-auto font-sans"
-      v-model="page"
-      :page-count="animesByGender.length"
-      :page-range="3"
-      :margin-pages="2"
-      :click-handler="pageHandler"
-      :prev-text="'Prev'"
-      :next-text="'Next'"
-      :container-class="'pagination'"
-      :page-class="'page-item'">
-    </paginate>
-
-  </div>
+  <AnimeListing
+    page-title="Animes by Genres"
+    menu-title="Genres"
+    :pagination="true"
+    :menu-options="options"
+    :menu-initial-value="genre"
+    :animes="animesByGender"
+    v-on:menu-item-selected="genreSelected"
+    v-on:page-selected="pageSelected"
+  ></AnimeListing>
 </template>
 
 <script>
-  import LatestAnime from '../components/LatestAnime'
-  import DropDownSection from '../components/DropDownSection'
-  import {mapState , mapGetters} from 'vuex'
-  import store from '../store/store'
+import AnimeListing from "../components/AnimeListing";
+import store from "../store/store";
+import { mapState } from "vuex";
 
-  export default {
-    name: "AnimesByLetter",
-    components:{
-      LatestAnime,
-      DropDownSection
+export default {
+  name: "AnimesByLetter",
+  components: {
+    AnimeListing
+  },
+  data() {
+    return {
+      page: 0,
+      genre: "accion",
+      options: [
+        "accion","artes-marciales","autos","aventura","colegial","comedia","cosas-de-la-vida","dementia","demonios","deportes",
+        "drama","ecchi","fantasia","harem","historico","josei","juegos","magia","mecha","militar","misterio","musica","nios",
+        "parodia","policial","psicologico","romance","samurai","sci-fi","seinen","shoujo","shoujo-ai","shounen","shounen-ai",
+        "sobrenatural","space","super poderes","terror","thriller","vampiros","yaoi","yuri",
+      ]
+    };
+  },
+  computed: {
+    ...mapState(["animesByGender"])
+  },
+  created() {
+    this.fetchData();
+  },
+  methods: {
+    genreSelected(genre) {
+      this.genre = genre;
+      this.fetchData();
     },
-    data(){
-      return{
-        page: 0,
-        searchModel: '',
-        gender: "accion",
-        options: [
-          'accion','artes-marciales','autos','aventura','colegial','comedia','cosas-de-la-vida','dementia','demonios','deportes',
-          'drama','ecchi','fantasia','harem','historico','josei','juegos','magia','mecha','militar','misterio','musica','nios',
-          'parodia','policial','psicologico','romance','samurai','sci-fi','seinen','shoujo','shoujo-ai','shounen','shounen-ai',
-          'sobrenatural','space','super poderes','terror','thriller','vampiros','yaoi','yuri',
-        ]
-      }
+    pageSelected(page) {
+      this.page = page;
+      this.fetchData();
     },
-    computed:{
-      ...mapState(['animesByGender' , 'isLoading']),
-    },
-    watch:{
-      gender: function(value){
-        this.gender = value;
-        let gender = this.gender;
-        let info = {gender: gender , page: this.page}
-        store.dispatch('GET_ANIME_GENDER' , info);
-      }
-    },
-    created(){
-      let info = {gender: this.gender , page: this.page}
-      store.dispatch('GET_ANIME_GENDER' , info)
-    },
-    methods:{
-      pageHandler(){
-        try{
-          let info = {gender: this.gender , page: this.page}
-          store.dispatch('GET_ANIME_GENDER' , info)
-        }catch(err){
-          console.log(err);
-        }
+    fetchData() {
+      // fetch data from the backend, and populate the data used by the listing component
+      try {
+        const info = { gender: this.genre, page: this.page };
+        store.dispatch("GET_ANIME_GENDER", info);
+      } catch (err) {
+        console.log(err);
       }
     }
-  };
+  }
+};
 </script>

--- a/src/frontend/src/views/AnimesByLetter.vue
+++ b/src/frontend/src/views/AnimesByLetter.vue
@@ -1,124 +1,57 @@
 <template>
-  <!-- all content -->
-  <div class="bg-white overflow-hidden">
-    <!-- top bar -->
-    <div class="border-b flex px-6 py-2 items-center flex-none">
-        <div class="flex flex-col">
-            <h3 class="text-grey-darkest mb-1 font-extrabold">👑 Animes by Letter</h3>
-            <div class="text-grey-dark text-sm truncate">
-              💖 Enjoy the world of anime
-            </div>
-        </div>
-
-        <div class="flex-1 justify-center hidden sm:flex">
-          <!--<v-suggest :data="animesByAlpha" type="text" placeholder="Search Anime ..." show-field="title" v-model="searchModel" class="border border-grey px-8 py-2 w-1/2 max-w-md outline-none rounded-l"></v-suggest> -->
-          <!--<input type="text" placeholder="Search Anime ..." class="border border-grey px-3 py-2 w-1/2 max-w-md outline-none rounded-l"/> -->
-
-           <!-- <button class="flex justify-center items-center bg-grey-lighter px-6 border border-grey border-l-0 rounded-r focus:outline-none hover:bg-gray-100">
-
-            <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" class="w-5 opacity-50"><g>
-              <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-              </g>
-            </svg>
-          </button> -->
-        </div>
-        <!-- href links to platforms and social media -->
-        <div class="flex justify-start items-center text-gray-500">
-          <h1>Alphabet</h1>
-          <select class="list-reset border border-purple-200 rounded m-3 w-20 font-sans" v-model="letter">
-            <option v-for="(char , index) in options"
-              :value="char"
-              :key="index"
-            >
-              {{char}}
-            </option>
-          </select>
-
-          <a href="https://github.com/ChrisMichaelPerezSantiago/ryuanime" class="block flex items-center hover:text-gray-700 mr-5">
-            <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <title>GitHub</title>
-              <path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0">
-              </path>
-            </svg>
-          </a>
-        </div>
-    </div>
-
-
-    <!-- content inside -->
-    <div class="px-6 py-4 flex-1 overflow-y-scroll scrollbar" id="style-1">
-      <DropDownSection class="ddSection"/> <!-- [TEMPORARY SOLUTION] navabr for phones -->
-
-      <div v-if="isLoading">
-        <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
-      </div>
-      <div class="flex flex-wrap" v-else>
-        <div class="w-full sm:w-1/2 md:w-1/2 lg:w-1/2 xl:w-1/2 mb-4" v-for="(anime , index) in animesByAlpha" :key="index">
-          <LatestAnime :anime="anime"/>
-        </div>
-      </div>
-    </div>
-
-     <paginate
-      class="paginator-container list-reset border border-purple-200 rounded w-auto font-sans"
-      v-model="page"
-      :page-count="animesByAlpha.length"
-      :page-range="3"
-      :margin-pages="2"
-      :click-handler="pageHandler"
-      :prev-text="'Prev'"
-      :next-text="'Next'"
-      :container-class="'pagination'"
-      :page-class="'page-item'">
-    </paginate>
-
-  </div>
+  <AnimeListing
+    page-title="Animes by Letter"
+    menu-title="Alphabet"
+    :pagination="true"
+    :menu-options="options"
+    :menu-initial-value="letter"
+    :animes="animesByAlpha"
+    v-on:menu-item-selected="letterSelected"
+    v-on:page-selected="pageSelected"
+  ></AnimeListing>
 </template>
 
 <script>
-  import LatestAnime from '../components/LatestAnime'
-  import DropDownSection from '../components/DropDownSection'
-  import {mapState , mapGetters} from 'vuex'
-  import store from '../store/store'
+import AnimeListing from "../components/AnimeListing";
+import store from "../store/store";
+import { mapState } from "vuex";
 
-  export default {
-    name: "AnimesByLetter",
-    components:{
-      LatestAnime,
-      DropDownSection
+export default {
+  name: "AnimesByLetter",
+  components: {
+    AnimeListing
+  },
+  data() {
+    return {
+      page: 0,
+      letter: "a",
+      options: [...Array(26).keys()].map(i => String.fromCharCode(i + 97)) //[a .. z]
+    };
+  },
+  computed: {
+    ...mapState(["animesByAlpha"])
+  },
+  created() {
+    this.fetchData();
+  },
+  methods: {
+    letterSelected(letter) {
+      this.letter = letter;
+      this.fetchData();
     },
-    data(){
-      return{
-        page: 0,
-        searchModel: '',
-        letter: "a",
-        options: [...Array(26).keys()].map(i => String.fromCharCode(i + 97)) //[a .. z]
-      }
+    pageSelected(page) {
+      this.page = page;
+      this.fetchData();
     },
-    computed:{
-      ...mapState(['animesByAlpha' , 'isLoading']),
-    },
-    watch:{
-      "letter": function(value){
-        this.letter = value;
-        let letter = this.letter;
-        let info = {letter: letter , page: this.page}
-        store.dispatch('GET_ANIME_ALPHA' , info);
-      }
-    },
-    created(){
-      let info = {letter: this.letter , page: this.page}
-      store.dispatch('GET_ANIME_ALPHA' , info)
-    },
-    methods:{
-      pageHandler(){
-        try{
-          let info = {letter: this.letter , page: this.page}
-          store.dispatch('GET_ANIME_ALPHA' , info)
-        }catch(err){
-          console.log(err);
-        }
+    fetchData() {
+      // fetch data from the backend, and populate the data used by the listing component
+      try {
+        const info = { letter: this.letter, page: this.page };
+        store.dispatch("GET_ANIME_ALPHA", info);
+      } catch (err) {
+        console.log(err);
       }
     }
-  };
+  }
+};
 </script>

--- a/src/frontend/src/views/Home.vue
+++ b/src/frontend/src/views/Home.vue
@@ -1,82 +1,26 @@
 <template>
-  <!-- all content -->
-  <div class="bg-white overflow-hidden">
-    <!-- top bar -->
-    <div class="border-b flex px-6 py-2 items-center flex-none">
-        <div class="flex flex-col">
-            <h3 class="text-grey-darkest mb-1 font-extrabold">👑 Last Animes Added</h3>
-            <div class="text-grey-dark text-sm truncate">
-              💖 Enjoy the world of anime
-            </div>
-        </div>
-
-        <div class="flex-1 justify-center hidden sm:flex">
-          <!--<v-suggest :data="latest" type="text" placeholder="Search Anime ..." show-field="title" v-model="latestModel" class="border border-grey px-8 py-2 w-1/2 max-w-md outline-none rounded-l"></v-suggest>-->
-          <!--<input type="text" placeholder="Search Anime ..." class="border border-grey px-3 py-2 w-1/2 max-w-md outline-none rounded-l"/> -->
-
-            <!--<button class="flex justify-center items-center bg-grey-lighter px-6 border border-grey border-l-0 rounded-r focus:outline-none hover:bg-gray-100">
-
-            <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" class="w-5 opacity-50"><g>
-              <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-              </g>
-            </svg>
-          </button> -->
-        </div>
-
-        <!-- href links to platforms and social media -->
-        <div class="flex justify-start items-center text-gray-500">
-          <a href="https://github.com/ChrisMichaelPerezSantiago/ryuanime" class="block flex items-center hover:text-gray-700 mr-5">
-            <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <title>GitHub</title>
-              <path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0">
-              </path>
-            </svg>
-          </a>
-        </div>
-
-    </div>
-
-
-    <!-- content inside -->
-    <div class="px-6 py-4 flex-1" id="style-1">
-      <DropDownSection class="ddSection"/> <!-- [TEMPORARY SOLUTION] navabr for phones -->
-
-      <div v-if="isLoading">
-        <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
-      </div>
-      <div class="flex flex-wrap" v-else>
-        <div class="w-full sm:w-1/2 md:w-1/2 lg:w-1/2 xl:w-1/2 mb-4" v-for="(anime , index) in latest" :key="index">
-          <LatestAnime :anime="anime"/>
-        </div>
-      </div>
-    </div>
-
-  </div>
+  <AnimeListing
+    page-title="Last Animes Added"
+    :pagination="false"
+    :animes="latest"
+  ></AnimeListing>
 </template>
 
 <script>
-  import LatestAnime from '../components/LatestAnime'
-  import DropDownSection from '../components/DropDownSection'
-  import {mapState , mapGetters} from 'vuex'
-  import store from '../store/store'
+import AnimeListing from "../components/AnimeListing";
+import store from "../store/store";
+import { mapState } from "vuex";
 
-  export default {
-    name: "home",
-    components:{
-      LatestAnime,
-      DropDownSection
-    },
-    data(){
-      return{
-        latestModel: ''
-      }
-    },
-    computed:{
-      ...mapState(['latest' , 'isLoading']),
-    },
-    created(){
-      store.dispatch('GET_LATEST_DATA')
-    }
-  };
+export default {
+  name: "home",
+  components: {
+    AnimeListing
+  },
+  computed: {
+    ...mapState(["latest"])
+  },
+  created() {
+    store.dispatch("GET_LATEST_DATA");
+  }
+};
 </script>
-

--- a/src/frontend/src/views/Movies.vue
+++ b/src/frontend/src/views/Movies.vue
@@ -1,102 +1,46 @@
 <template>
-  <!-- all content -->
-  <div class="bg-white overflow-hidden">
-    <!-- top bar -->
-    <div class="border-b flex px-6 py-2 items-center flex-none">
-        <div class="flex flex-col">
-            <h3 class="text-grey-darkest mb-1 font-extrabold">👑 Movies</h3>
-            <div class="text-grey-dark text-sm truncate">
-              💖 Enjoy the world of anime
-            </div>
-        </div>
-
-        <div class="flex-1 justify-center hidden sm:flex">
-          <!--<v-suggest :data="movies" type="text" placeholder="Search Anime ..." show-field="title" v-model="searchModel" class="border border-grey px-8 py-2 w-1/2 max-w-md outline-none rounded-l"></v-suggest> -->
-          <!--<input type="text" placeholder="Search Anime ..." class="border border-grey px-3 py-2 w-1/2 max-w-md outline-none rounded-l"/> -->
-
-            <!--<button class="flex justify-center items-center bg-grey-lighter px-6 border border-grey border-l-0 rounded-r focus:outline-none hover:bg-gray-100">
-
-            <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" class="w-5 opacity-50"><g>
-              <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-              </g>
-            </svg>
-          </button>-->
-        </div>
-        <!-- href links to platforms and social media -->
-        <div class="flex justify-start items-center text-gray-500">
-          <a href="https://github.com/ChrisMichaelPerezSantiago/ryuanime" class="block flex items-center hover:text-gray-700 mr-5">
-            <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <title>GitHub</title>
-              <path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0">
-              </path>
-            </svg>
-          </a>
-        </div>
-    </div>
-
-
-    <!-- content inside -->
-    <div class="px-6 py-4 flex-1 overflow-y-scroll scrollbar" id="style-1">
-      <DropDownSection class="ddSection"/> <!-- [TEMPORARY SOLUTION] navabr for phones -->
-
-      <div v-if="isLoading">
-        <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
-      </div>
-      <div class="flex flex-wrap" v-else>
-        <div class="w-full sm:w-1/2 md:w-1/2 lg:w-1/2 xl:w-1/2 mb-4" v-for="(anime , index) in movies" :key="index">
-          <LatestAnime :anime="anime"/>
-        </div>
-      </div>
-    </div>
-
-     <paginate
-      class="paginator-container list-reset border border-purple-200 rounded w-auto font-sans"
-      v-model="page"
-      :page-count="movies.length"
-      :page-range="3"
-      :margin-pages="2"
-      :click-handler="pageHandler"
-      :prev-text="'Prev'"
-      :next-text="'Next'"
-      :container-class="'pagination'"
-      :page-class="'page-item'">
-    </paginate>
-
-  </div>
+  <AnimeListing
+    page-title="Movies"
+    :pagination="true"
+    :animes="movies"
+    v-on:page-selected="pageSelected"
+  ></AnimeListing>
 </template>
 
 <script>
-  import LatestAnime from '../components/LatestAnime'
-  import DropDownSection from '../components/DropDownSection'
-  import {mapState , mapGetters} from 'vuex'
-  import store from '../store/store'
+import AnimeListing from "../components/AnimeListing";
+import store from "../store/store";
+import { mapState } from "vuex";
 
-  export default {
-    name: "Movies",
-    components:{
-      LatestAnime,
-      DropDownSection
+export default {
+  name: "Movies",
+  components: {
+    AnimeListing
+  },
+  data() {
+    return {
+      page: 0
+    };
+  },
+  computed: {
+    ...mapState(["movies"])
+  },
+  created() {
+    this.fetchData();
+  },
+  methods: {
+    pageSelected(page) {
+      this.page = page;
+      this.fetchData();
     },
-    data(){
-      return{
-        page: 0,
-        searchModel: '',
-      }
-    },
-    computed:{
-      ...mapState(['movies' , 'isLoading']),
-    },
-    created(){
-      store.dispatch('GET_ANIME_MOVIES' , this.page);
-    },
-    methods:{
-      pageHandler(){
-        try{
-          store.dispatch('GET_ANIME_MOVIES' , this.page)
-        }catch(err){
-          console.log(err);
-        }
+    fetchData() {
+      // fetch data from the backend, and populate the data used by the listing component
+      try {
+        store.dispatch("GET_ANIME_MOVIES", this.page);
+      } catch (err) {
+        console.log(err);
       }
     }
-  };
+  }
+};
 </script>

--- a/src/frontend/src/views/Ovas.vue
+++ b/src/frontend/src/views/Ovas.vue
@@ -1,102 +1,46 @@
 <template>
-  <!-- all content -->
-  <div class="bg-white overflow-hidden">
-    <!-- top bar -->
-    <div class="border-b flex px-6 py-2 items-center flex-none">
-        <div class="flex flex-col">
-            <h3 class="text-grey-darkest mb-1 font-extrabold">👑 Ova </h3>
-            <div class="text-grey-dark text-sm truncate">
-              💖 Enjoy the world of anime
-            </div>
-        </div>
-
-        <div class="flex-1 justify-center hidden sm:flex">
-          <!--<v-suggest :data="ovas" type="text" placeholder="Search Anime ..." show-field="title" v-model="searchModel" class="border border-grey px-8 py-2 w-1/2 max-w-md outline-none rounded-l"></v-suggest> -->
-          <!--<input type="text" placeholder="Search Anime ..." class="border border-grey px-3 py-2 w-1/2 max-w-md outline-none rounded-l"/> -->
-
-            <!--<button class="flex justify-center items-center bg-grey-lighter px-6 border border-grey border-l-0 rounded-r focus:outline-none hover:bg-gray-100">
-
-            <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" class="w-5 opacity-50"><g>
-              <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-              </g>
-            </svg>
-          </button> -->
-        </div>
-        <!-- href links to platforms and social media -->
-        <div class="flex justify-start items-center text-gray-500">
-          <a href="https://github.com/ChrisMichaelPerezSantiago/ryuanime" class="block flex items-center hover:text-gray-700 mr-5">
-            <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <title>GitHub</title>
-              <path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0">
-              </path>
-            </svg>
-          </a>
-        </div>
-    </div>
-
-
-    <!-- content inside -->
-    <div class="px-6 py-4 flex-1 overflow-y-scroll scrollbar" id="style-1">
-      <DropDownSection class="ddSection"/> <!-- [TEMPORARY SOLUTION] navabr for phones -->
-
-      <div v-if="isLoading">
-        <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
-      </div>
-      <div class="flex flex-wrap" v-else>
-        <div class="w-full sm:w-1/2 md:w-1/2 lg:w-1/2 xl:w-1/2 mb-4" v-for="(anime , index) in ovas" :key="index">
-          <LatestAnime :anime="anime"/>
-        </div>
-      </div>
-    </div>
-
-     <paginate
-      class="paginator-container list-reset border border-purple-200 rounded w-auto font-sans"
-      v-model="page"
-      :page-count="ovas.length"
-      :page-range="3"
-      :margin-pages="2"
-      :click-handler="pageHandler"
-      :prev-text="'Prev'"
-      :next-text="'Next'"
-      :container-class="'pagination'"
-      :page-class="'page-item'">
-    </paginate>
-
-  </div>
+  <AnimeListing
+    page-title="Ova"
+    :pagination="true"
+    :animes="ovas"
+    v-on:page-selected="pageSelected"
+  ></AnimeListing>
 </template>
 
 <script>
-  import LatestAnime from '../components/LatestAnime'
-  import DropDownSection from '../components/DropDownSection'
-  import {mapState , mapGetters} from 'vuex'
-  import store from '../store/store'
+import AnimeListing from "../components/AnimeListing";
+import store from "../store/store";
+import { mapState } from "vuex";
 
-  export default {
-    name: "Ovas",
-    components:{
-      LatestAnime,
-      DropDownSection
+export default {
+  name: "Ovas",
+  components: {
+    AnimeListing
+  },
+  data() {
+    return {
+      page: 0
+    };
+  },
+  computed: {
+    ...mapState(["ovas"])
+  },
+  created() {
+    this.fetchData();
+  },
+  methods: {
+    pageSelected(page) {
+      this.page = page;
+      this.fetchData();
     },
-    data(){
-      return{
-        page: 0,
-        searchModel: '',
-      }
-    },
-    computed:{
-      ...mapState(['ovas' , 'isLoading']),
-    },
-    created(){
-      store.dispatch('GET_ANIME_OVAS' , this.page);
-    },
-    methods:{
-      pageHandler(){
-        try{
-          store.dispatch('GET_ANIME_OVAS' , this.page)
-        }catch(err){
-          console.log(err);
-        }
+    fetchData() {
+      // fetch data from the backend, and populate the data used by the listing component
+      try {
+        store.dispatch("GET_ANIME_OVAS", this.page);
+      } catch (err) {
+        console.log(err);
       }
     }
-  };
+  }
+};
 </script>


### PR DESCRIPTION
Hi,

I was planning on using some spare time this weekend to either fix the mobile display (which I broke) or take a look at the pagination issue #70 

However, I realized the pagination, and also the CSS classes for the anime listing sections repeated. I've identified the anime listing sections were:

- Home/Latest
- Alphabet
- Genres
- Movies
- Ovas

Search as well, but there are more nuances in that view, so I skipped it for now.

Then for all these sections, this PR adds a new component `AnimeListing.vue`, which uses a collection from vuex store, that is passed as a prop/argument to the component, to render that collection as a list.

There are also props to control the drop down menu - when available - and to toggle pagination.

This way, after this PR we should have a single place for pagination of animes, and also a single place where the `LatestAnime` is displayed multiple times. Making it - hopefully - easier to fix the issues with responsiveness and with the pagination (which now I have a vague idea, or at least a starting point to investigate).

Cheers
Bruno

ps: after the change was done, I was running `npm run serve`, so looked at the linter output, and started fixing it until only errors were related to `console.log` or to the list of genres :+1: 